### PR TITLE
restricing dev and admin wikis like on refreshed

### DIFF
--- a/DeepSea.skin.php
+++ b/DeepSea.skin.php
@@ -499,15 +499,19 @@ class DeepSeaTemplate extends BaseTemplate {
 							'name' => 'CUUSOO',
 							'hover' => 'The LEGO CUUSOO Wiki'
 						),
-						'dev' => array(
-							'name' => 'Dev',
-							'hover' => 'The Brickimedia development wiki'
-						),
-						'admin' => array(
+					);
+					if ( in_array('sysop', $groups ) ) {
+						$bmProject['admin'] = array(
 							'name' => 'Admin',
 							'hover' => 'The admin organisation wiki'
-						),
-					);
+						);
+					}
+					if ( in_array('sysadmin', $groups ) ) {
+						$bmProject['sysadmin'] = array(
+							'name' = 'Dev',
+							'hover' = 'The Brickimedia development wiki'
+						);
+					}
 					global $bmProject;
 
 ?>


### PR DESCRIPTION
Here's what changed..
If in the sysop group, the admin wiki appears on the top left menu.
If in the sysadmin group, the development wiki appears on the top left menu.
